### PR TITLE
2024-12-05 - Change PhraseGenerator from public to open

### DIFF
--- a/Sources/PhraseKit/PhraseGenerator.swift
+++ b/Sources/PhraseKit/PhraseGenerator.swift
@@ -9,7 +9,7 @@ import Foundation
 /// `PhraseGenerator` is a class designed to generate random, human-readable phrases
 /// composed of various parts of speech, such as adjectives, nouns, verbs, and adverbs.
 @available(iOS 12.0, macOS 10.14, macCatalyst 13.0, tvOS 12.0, watchOS 5.0, visionOS 1.0, *)
-public class PhraseGenerator {
+open class PhraseGenerator {
 
     /// A list of nouns used to generate phrases.
     internal var nouns: [String]


### PR DESCRIPTION
# Pull Request

> [!Important]
> Please ensure you have named your pull request with the proper naming convention. This is usually in the `YYYY-MM-DD -` format. This aids in maintaining the codebase in a consistent and uniform format.

## Description

<!--
    Please provide a detailed description of the changes made in this Pull Request.
    This should include:
    - A summary of what was changed.
    - Specific bugs or issues that were fixed.
    - Any new features or significant updates that were added.
    - Any deprecated features or removed functionality.
-->

## Related Issues
Fixes an issue where users can't inherit PhraseGenerator due to it being public and not open. 

## Local Testing

- [ ✓ ] I have tested these changes on a local environment and confirm they work as expected.

## Checklist

- [ ✓ ] My changes generate no new warnings or errors.
- [ ✓ ] I have performed a self-review of my own code/documentation.
- [ ✓ ] I have updated the change log file (if applicable), linking to the relevant sections.
- [ ✓ ] I have checked and corrected any mis-spellings and grammatical errors.
- [ ✓ ] I have ensured that any dependencies are updated and documented.
- [ ✓ ] I have included relevant unit tests and they pass.
- [ ✓ ] I have added or updated documentation as needed.

## Additional Notes
Minor change, but can't inherit PhraseGenerator and implement my own generator without it. 
